### PR TITLE
Fix broken unittests

### DIFF
--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -282,22 +282,6 @@ def compare_bbox(true_bbox: tuple|list, pred_bbox: tuple|list, metric: str = "io
         
     return iou_value
 
-def createTestMatrix():
-
-        data = np.array([
-            [[0, -0.2104005415, -0.4138471552],
-            [-0.2104005415, 0, -0.2586695576],
-            [-0.4138471552, -0.2586695576, 0]],
-            [[0, 0, 0],
-            [0, 0, 0],
-            [0, 0, 0]],
-            [[0, -0.2246186874, -0.3063050874],
-            [-0.2246186874, 0, -0.1064981483],
-            [-0.3063050874, -0.1064981483, 0]]
-        ])
-
-        np.save("tests/varon_correct.npy", data)
-
 def varon_iteration(dir_path: str, c_threshold: float, num_bands: int, output_file: Optional[str]=None, images: Optional[list]=None, pixels: Optional[int]= 255) -> np.ndarray:
     """
     consumes a path to a directory (easy training), and name of the output file. For each

--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -298,7 +298,7 @@ def createTestMatrix():
 
         np.save("tests/varon_correct.npy", data)
 
-def varon_iteration(dir_path: str, output_file: str, c_threshold: float, num_bands: int, images: Optional[np.ndarray]=None, pixels: Optional[int]= 255):
+def varon_iteration(dir_path: str, c_threshold: float, num_bands: int, output_file: Optional[str]=None, images: Optional[list]=None, pixels: Optional[int]= 255) -> np.ndarray:
     """
     consumes a path to a directory (easy training), and name of the output file. For each
     folder of images, it computes the varon ratio between each image creating
@@ -307,16 +307,19 @@ def varon_iteration(dir_path: str, output_file: str, c_threshold: float, num_ban
 
     Args:
         dir_path (str): path to directory with images
-        output_file (str): path to output file for computed matrix
         c_threshold (float): z-threshold for outlier filtering
-        num_folders (Optional[int], optional): number of folders to process. Defaults to None.
+        num_bands (int): number of bands to process
+        output_file (Optional[str], optional): name of the file to save the computed matrix. Computed matrix won't be saved if not specified. Defaults to None.
+        images (Optional[list], optional): name of folders to process. Defaults to None.
+        pixels (Optional[int], optional): number of pixels to process. Defaults to 255.
+        save_path (Optional[str], optional): path to save the computed matrix. Matrix won't be saved if not specified. Defaults to None.
         If None, all folders will be processed
 
     Returns:
         np.ndarray: compute matrix containing varon ratios for all frequency channels
     """
     final_matrix = []
-    num_images = len(images)
+
     image_file_names = [
         "TOA_AVIRIS_460nm.tif",
         "TOA_AVIRIS_550nm.tif",
@@ -335,12 +338,9 @@ def varon_iteration(dir_path: str, output_file: str, c_threshold: float, num_ban
         "TOA_WV3_SWIR7.tif",
         "TOA_WV3_SWIR8.tif"]
 
-    all_folders = os.listdir(dir_path)
-    
-    if num_images is not None:
-        all_folders = all_folders[:num_images]
+    folders_to_process = os.listdir(dir_path) if images is None else images
 
-    for image_folder in all_folders:
+    for image_folder in folders_to_process:
         folder_path = os.path.join(dir_path, image_folder)
         
         if not os.path.isdir(folder_path):
@@ -380,6 +380,7 @@ def varon_iteration(dir_path: str, output_file: str, c_threshold: float, num_ban
 
         final_matrix.append(current_matrix)
 
-    np.save(output_file, final_matrix)
+    if output_file:
+        np.save(output_file, final_matrix)
 
     return final_matrix

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -12,8 +12,8 @@ class TestCreateDataset(unittest.TestCase):
         
         # Check the shape and data type of a single batch
         for images, labels in dataset.take(1):
-            self.assertEqual(images.shape, (16, 512, 512), "Images shape does not match expected dimensions")
-            self.assertEqual(labels.shape, (1, 512, 512), "Labels shape does not match expected dimensions")
+            self.assertEqual(images.shape, (512, 512, 16), "Images shape does not match expected dimensions")
+            self.assertEqual(labels.shape, (512, 512, 1), "Labels shape does not match expected dimensions")
             self.assertEqual(images.dtype, tf.float32, "Images dtype should be tf.float32")
             self.assertEqual(labels.dtype, tf.float32, "Labels dtype should be tf.float32")
 

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -4,6 +4,21 @@ from pathlib import Path
 
 from src import image_utils
 
+def get_expected_varon_matrix():
+    data = np.array([
+        [[0, -0.2104005415, -0.4138471552],
+        [-0.2104005415, 0, -0.2586695576],
+        [-0.4138471552, -0.2586695576, 0]],
+        [[0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]],
+        [[0, -0.2246186874, -0.3063050874],
+        [-0.2246186874, 0, -0.1064981483],
+        [-0.3063050874, -0.1064981483, 0]]
+    ])
+
+    return data
+
 class TestImageUtils(unittest.TestCase):
     def setUp(self):
         self.files_to_remove = []

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -61,12 +61,9 @@ class TestImageUtils(unittest.TestCase):
         images = ["ang20190927t184620_r7541_c401_w151_h151",
                   "ang20190927t153023_r7101_c126_w151_h151",
                   "ang20191019t175004_r8192_c256_w512_h512"]
-        compute_matrix = image_utils.varon_iteration("data/raw_data/STARCOP_train_easy", "tests/varon.npy", 2, 3, images,5)
-        self.files_to_remove.append('tests/varon.npy') 
-        
-        image_utils.createTestMatrix()
-        correct_matrix = np.load("tests/varon_correct.npy")
-        self.files_to_remove.append('tests/varon_correct.npy') 
+        compute_matrix = image_utils.varon_iteration("data/raw_data/STARCOP_train_easy", 2, 3, images=images, pixels=5)
+
+        correct_matrix = get_expected_varon_matrix()
         np.testing.assert_almost_equal(correct_matrix, compute_matrix, decimal=6) 
     
     


### PR DESCRIPTION
Fixed the following to fix the broken unittests
- test_dataset_creation was expecting the incorrect data format
- varon_iteration was incorrectly parsing the images parameter causing tests to fail on some OS

Did some cleanup of docstrings and testing code